### PR TITLE
Update TarConv 

### DIFF
--- a/TarCon.pl
+++ b/TarCon.pl
@@ -66,7 +66,7 @@ if(defined $dir){
 }
 
 if(defined $file){
-
+	fileConverter($sFile);
 }
 
 sub usage{


### PR DESCRIPTION
In this Commit, if we only give the name of the file, then only the file is converted to perl instead of whole directory.
Bug is fixed in this Merge.
